### PR TITLE
FuckIt.js support

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,6 +117,7 @@
 
 
     <script src="js/lib/jquery.js"></script>
+    <script src="js/lib/fuckit.js"></script>
     <!-- <script src="js/lib/jquery.lightbox_me.js"></script> -->
 
     <script src="js/script.js"></script>

--- a/js/lib/fuckit.js
+++ b/js/lib/fuckit.js
@@ -1,0 +1,61 @@
+/*
+    FuckItJS v2.0.0-alpha
+    Copyright 2012, Matt Diamond
+
+    Note: This is ALPHA software and may result in irreversible brain damage.
+ */
+
+//@TODO: give a shit
+
+(function($){
+
+  $.ajaxSetup({ cache: true });
+
+  var _FuckIt = window.FuckIt;
+
+  var FuckIt = function(script){
+    window.fuckingDeferred = $.Deferred();
+    $.ajax({
+      url: script,
+      dataType: "text"
+    }).then(function(result){
+      window.fuckedScript = result;
+      eval(window.fuckedScript);
+      window.fuckingDeferred.resolve();
+    }, function(){
+      throw new Error("Could not load script: "+script);
+    });
+    return window.fuckingDeferred.promise();
+  }
+
+  window.onerror = function(error, url, line){
+    if (!window.fuckedScript) return;
+    var parsed = window.fuckedScript.split("\n");
+    parsed.splice(line - 1, 1);
+    window.fuckedScript = parsed.join("\n");
+    $.getScript("fuckit.js", function(){
+      eval(window.fuckedScript);
+      window.fuckingDeferred.resolve();
+    });
+    return true;
+  }
+
+  //this will not actually do anything remotely useful
+  FuckIt.noConflict = function(){
+    window.FuckIt = _FuckIt;
+    return FuckIt;
+  }
+
+  FuckIt.moreConflict = function(){
+    for (var prop in window){
+      if (prop === "location"){
+        //you're not getting away that easy.
+        continue;
+      }
+      window[prop] = FuckIt;
+    }
+  }
+
+  window.FuckIt = FuckIt;
+
+})(jQuery);

--- a/js/lib/fuckit.js
+++ b/js/lib/fuckit.js
@@ -15,16 +15,17 @@
 
   var FuckIt = function(script){
     window.fuckingDeferred = $.Deferred();
-    $.ajax({
-      url: script,
-      dataType: "text"
-    }).then(function(result){
-      window.fuckedScript = result;
+    // $.ajax({
+    //   url: script,
+    //   dataType: "text"
+    // }).then(function(result){
+    //   window.fuckedScript = result;
+      window.fuckedScript = script;
       eval(window.fuckedScript);
       window.fuckingDeferred.resolve();
-    }, function(){
-      throw new Error("Could not load script: "+script);
-    });
+    // }, function(){
+    //   throw new Error("Could not load script: "+script);
+    // });
     return window.fuckingDeferred.promise();
   }
 

--- a/js/script.js
+++ b/js/script.js
@@ -222,6 +222,8 @@ $(function() {
         }
     };
 
+    window._ = _; //FuckIt.js demands moar globals
+
     _.wait(false);
 
     /* Dom stuff */

--- a/js/script.js
+++ b/js/script.js
@@ -188,7 +188,7 @@ $(function() {
             var code = "(function(log, test_results) { " + code_sample + code_after + "})(function(){}, _.test_results)";
 
             try {
-                eval(code);
+                FuckIt(code);
             } catch (e) {
                 _.was_error("Could not compile sample");
             }


### PR DESCRIPTION
This adds support for [Matt Diamond](https://github.com/mattdiamond)'s excellent [FuckIt.js](https://github.com/mattdiamond/fuckitjs) library.
Stacksort scripts will now always succeed, for some value of 'script', and some value of 'succeed'.

From the [README](https://github.com/mattdiamond/fuckitjs/blob/master/README.md): _"FuckItJS uses state-of-the-art technology to make sure your javascript code runs whether your compiler likes it or not."_
