### PR TITLE
Added array length check

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -200,19 +200,23 @@ $(function() {
             try {
                 var output = JSON.stringify(value);
                 if(value && typeof value === 'object' && Object.keys(value).length > 0) {
-                    $('#output').val(output);
-                    _.logger("Your array was sorted!", "success");
+                    if (JSON.parse($('#input').val()).length !== Object.keys(value).length) {
+                        _.was_error("The array's length was changed");
+                    } else {
+                        $('#output').val(output);
+                        _.logger("Your array was sorted!", "success");
 
-                    var answer_id = _.answers[_.item].answer_id;
-                    var link = _.answers[_.item].link;
-                    $('#answer-used a').attr({'href': link}).text(answer_id);
+                        var answer_id = _.answers[_.item].answer_id;
+                        var link = _.answers[_.item].link;
+                        $('#answer-used a').attr({'href': link}).text(answer_id);
 
-                    $('#sort').attr('disabled', false).text('Sort Again');
-                    _.wait(false);
-                    _.item++;
-                    setTimeout(function() {
-                        $('.done').fadeIn();
-                    }, 400);
+                        $('#sort').attr('disabled', false).text('Sort Again');
+                        _.wait(false);
+                        _.item++;
+                        setTimeout(function() {
+                            $('.done').fadeIn();
+                        }, 400);
+                    }
                 } else {
                     _.was_error("Didn't return a value.");
                 }


### PR DESCRIPTION
I noticed that there was an issue where the first result with valid code that StackOverflow brings up sorts unique values, so any duplicate values will be removed. For example, `[1, 5, 9, 3, 4, 7, 13, 2, 13, 5, 9, 7]` becomes `[1,2,3,4,5,7,9,13]`.

Solved the problem by checking that the length of the sorted array is equal to the length of the unsorted array.